### PR TITLE
네비게이션 메인영역 푸터 일부 마크업 완성

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
 <html lang="ko">
+
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>여행은 살아보는 거야 - 에어비앤비</title>
 </head>
+
 <body>
   <!-- 조한 part -->
   <header></header>
@@ -26,15 +28,129 @@
       <li class="navigation__item"><button type="button" class="navigation__item__button">호숫가</button></li>
       <li class="navigation__item"><button type="button" class="navigation__item__button">북극</button></li>
       <li class="navigation__item"><button type="button" class="navigation__item__button">멋진 수영장/button></li>
-        <li class="navigation__item"><button type="button" class="navigation__item__button">동굴</button></li>
-        <li class="navigation__item"><button type="button" class="navigation__item__button">서핑</button></li>
-        <li class="navigation__item"><button type="button" class="navigation__item__button">최고의 전망</button></li>
-        <li class="navigation__item"><button type="button" class="navigation__item__button">복토 주택</button></li>
-        <li class="navigation__item"><button type="button" class="navigation__item__button">열대지역</button></li>
-      </ul>
+      <li class="navigation__item"><button type="button" class="navigation__item__button">동굴</button></li>
+      <li class="navigation__item"><button type="button" class="navigation__item__button">서핑</button></li>
+      <li class="navigation__item"><button type="button" class="navigation__item__button">최고의 전망</button></li>
+      <li class="navigation__item"><button type="button" class="navigation__item__button">복토 주택</button></li>
+      <li class="navigation__item"><button type="button" class="navigation__item__button">열대지역</button></li>
+    </ul>
     <button type="button" class="navigation__left arrow-button" aria-label="이전 숙소 유형 더보기"></button>
     <button type="button" class="navigation__right arrow-button" aria-label="다음 숙소 유형 더보기"></button>
     <button type="button" class="navigation__filter">필터</button>
   </nav>
+  <main>
+    <h3 class="sr-only">섬 유형의 숙소들</h3>
+    <section class="accommodation__container">
+      <a href="/" class="accommodation__link">
+        <article class="accommodation__item">
+          <!-- h4 변경 -->
+          <h4 class="sr-only">몰디브에 위치한 워터 방갈로</h4>
+          <div class="accommodation__item__image">
+            <!-- src, alt 변경 -->
+            <img src="/" alt="">
+            <button type="button" class="arrow-button" aria-label="다음 숙소 이미지 더보기"></button>
+          </div>
+          <h5 class="sr-only">숙소 정보</h5>
+          <!-- 숙소 정보 변경 -->
+          <ul class="accommodation__item__brief">
+            <li class="font-bold">MV, 몰디브</li>
+            <li>6,596km 거리</li>
+            <li>9월 24일~29일</li>
+            <li class="font-bold">₩781,552 /박</li>
+            <li class="review" aria-label="평점">NEW</li>
+          </ul>
+          <button class="accommodation__item__favorite" aria-label="숙소 찜하기"></button>
+        </article>
+      </a>
+      <a href="/" class="accommodation__link">
+        <article class="accommodation__item">
+          <!-- h4 변경 -->
+          <h4 class="sr-only">몰디브에 위치한 워터 방갈로</h4>
+          <div class="accommodation__item__image">
+            <!-- src, alt 변경 -->
+            <img src="/" alt="">
+            <button type="button" class="arrow-button" aria-label="다음 숙소 이미지 더보기"></button>
+          </div>
+          <h5 class="sr-only">숙소 정보</h5>
+          <!-- 숙소 정보 변경 -->
+          <ul class="accommodation__item__brief">
+            <li class="font-bold">MV, 몰디브</li>
+            <li>6,596km 거리</li>
+            <li>9월 24일~29일</li>
+            <li class="font-bold">₩781,552 /박</li>
+            <li class="review" aria-label="평점">NEW</li>
+          </ul>
+          <button class="accommodation__item__favorite" aria-label="숙소 찜하기"></button>
+        </article>
+      </a>
+      <a href="/" class="accommodation__link">
+        <article class="accommodation__item">
+          <!-- h4 변경 -->
+          <h4 class="sr-only">몰디브에 위치한 워터 방갈로</h4>
+          <div class="accommodation__item__image">
+            <!-- src, alt 변경 -->
+            <img src="/" alt="">
+            <button type="button" class="arrow-button" aria-label="다음 숙소 이미지 더보기"></button>
+          </div>
+          <h5 class="sr-only">숙소 정보</h5>
+          <!-- 숙소 정보 변경 -->
+          <ul class="accommodation__item__brief">
+            <li class="font-bold">MV, 몰디브</li>
+            <li>6,596km 거리</li>
+            <li>9월 24일~29일</li>
+            <li class="font-bold">₩781,552 /박</li>
+            <li class="review" aria-label="평점">NEW</li>
+          </ul>
+          <button class="accommodation__item__favorite" aria-label="숙소 찜하기"></button>
+        </article>
+      </a>
+      <a href="/" class="accommodation__link">
+        <article class="accommodation__item">
+          <!-- h4 변경 -->
+          <h4 class="sr-only">몰디브에 위치한 워터 방갈로</h4>
+          <div class="accommodation__item__image">
+            <!-- src, alt 변경 -->
+            <img src="/" alt="">
+            <button type="button" class="arrow-button" aria-label="다음 숙소 이미지 더보기"></button>
+          </div>
+          <h5 class="sr-only">숙소 정보</h5>
+          <!-- 숙소 정보 변경 -->
+          <ul class="accommodation__item__brief">
+            <li class="font-bold">MV, 몰디브</li>
+            <li>6,596km 거리</li>
+            <li>9월 24일~29일</li>
+            <li class="font-bold">₩781,552 /박</li>
+            <li class="review" aria-label="평점">NEW</li>
+          </ul>
+          <button class="accommodation__item__favorite" aria-label="숙소 찜하기"></button>
+        </article>
+      </a>
+      <a href="/" class="accommodation__link">
+        <article class="accommodation__item">
+          <!-- h4 변경 -->
+          <h4 class="sr-only">몰디브에 위치한 워터 방갈로</h4>
+          <div class="accommodation__item__image">
+            <!-- src, alt 변경 -->
+            <img src="/" alt="">
+            <button type="button" class="arrow-button" aria-label="다음 숙소 이미지 더보기"></button>
+          </div>
+          <h5 class="sr-only">숙소 정보</h5>
+          <!-- 숙소 정보 변경 -->
+          <ul class="accommodation__item__brief">
+            <li class="font-bold">MV, 몰디브</li>
+            <li>6,596km 거리</li>
+            <li>9월 24일~29일</li>
+            <li class="font-bold">₩781,552 /박</li>
+            <li class="review" aria-label="평점">NEW</li>
+          </ul>
+          <button class="accommodation__item__favorite" aria-label="숙소 찜하기"></button>
+        </article>
+      </a>
+    </section>
+    <div class="accommodation__more">섬 카테고리 계속 검색하기<button type="button" class="accommodation__more__button">더
+        보기</button></div>
+    <button type="button" class="accommodation__map">지도 표시하기</button>
+  </main>
 </body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -3,8 +3,6 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>여행은 살아보는 거야 - 에어비앤비</title>
 </head>
 
@@ -41,8 +39,8 @@
   <main>
     <h3 class="sr-only">섬 유형의 숙소들</h3>
     <section class="accommodation__container">
-      <a href="/" class="accommodation__link">
-        <article class="accommodation__item">
+      <article class="accommodation__item">
+        <a href="/" class="accommodation__link">
           <!-- h4 변경 -->
           <h4 class="sr-only">몰디브에 위치한 워터 방갈로</h4>
           <div class="accommodation__item__image">
@@ -53,17 +51,17 @@
           <h5 class="sr-only">숙소 정보</h5>
           <!-- 숙소 정보 변경 -->
           <ul class="accommodation__item__brief">
-            <li class="font-bold">MV, 몰디브</li>
+            <li class="font-bold"><abbr title="Maldiv">MV, </abbr>몰디브</li>
             <li>6,596km 거리</li>
             <li>9월 24일~29일</li>
             <li class="font-bold">₩781,552 /박</li>
-            <li class="review" aria-label="평점">NEW</li>
+            <li class="review" aria-label="새로운 숙소라 아직 평점이 없습니다">NEW</li>
           </ul>
           <button class="accommodation__item__favorite" aria-label="숙소 찜하기"></button>
-        </article>
-      </a>
-      <a href="/" class="accommodation__link">
-        <article class="accommodation__item">
+        </a>
+      </article>
+      <article class="accommodation__item">
+        <a href="/" class="accommodation__link">
           <!-- h4 변경 -->
           <h4 class="sr-only">몰디브에 위치한 워터 방갈로</h4>
           <div class="accommodation__item__image">
@@ -74,17 +72,17 @@
           <h5 class="sr-only">숙소 정보</h5>
           <!-- 숙소 정보 변경 -->
           <ul class="accommodation__item__brief">
-            <li class="font-bold">MV, 몰디브</li>
+            <li class="font-bold"><abbr title="Maldiv">MV, </abbr>몰디브</li>
             <li>6,596km 거리</li>
             <li>9월 24일~29일</li>
             <li class="font-bold">₩781,552 /박</li>
-            <li class="review" aria-label="평점">NEW</li>
+            <li class="review" aria-label="새로운 숙소라 아직 평점이 없습니다">NEW</li>
           </ul>
           <button class="accommodation__item__favorite" aria-label="숙소 찜하기"></button>
-        </article>
-      </a>
-      <a href="/" class="accommodation__link">
-        <article class="accommodation__item">
+        </a>
+      </article>
+      <article class="accommodation__item">
+        <a href="/" class="accommodation__link">
           <!-- h4 변경 -->
           <h4 class="sr-only">몰디브에 위치한 워터 방갈로</h4>
           <div class="accommodation__item__image">
@@ -95,17 +93,17 @@
           <h5 class="sr-only">숙소 정보</h5>
           <!-- 숙소 정보 변경 -->
           <ul class="accommodation__item__brief">
-            <li class="font-bold">MV, 몰디브</li>
+            <li class="font-bold"><abbr title="Maldiv">MV, </abbr>몰디브</li>
             <li>6,596km 거리</li>
             <li>9월 24일~29일</li>
             <li class="font-bold">₩781,552 /박</li>
-            <li class="review" aria-label="평점">NEW</li>
+            <li class="review" aria-label="새로운 숙소라 아직 평점이 없습니다">NEW</li>
           </ul>
           <button class="accommodation__item__favorite" aria-label="숙소 찜하기"></button>
-        </article>
-      </a>
-      <a href="/" class="accommodation__link">
-        <article class="accommodation__item">
+        </a>
+      </article>
+      <article class="accommodation__item">
+        <a href="/" class="accommodation__link">
           <!-- h4 변경 -->
           <h4 class="sr-only">몰디브에 위치한 워터 방갈로</h4>
           <div class="accommodation__item__image">
@@ -116,17 +114,17 @@
           <h5 class="sr-only">숙소 정보</h5>
           <!-- 숙소 정보 변경 -->
           <ul class="accommodation__item__brief">
-            <li class="font-bold">MV, 몰디브</li>
+            <li class="font-bold"><abbr title="Maldiv">MV, </abbr>몰디브</li>
             <li>6,596km 거리</li>
             <li>9월 24일~29일</li>
             <li class="font-bold">₩781,552 /박</li>
-            <li class="review" aria-label="평점">NEW</li>
+            <li class="review" aria-label="새로운 숙소라 아직 평점이 없습니다">NEW</li>
           </ul>
           <button class="accommodation__item__favorite" aria-label="숙소 찜하기"></button>
-        </article>
-      </a>
-      <a href="/" class="accommodation__link">
-        <article class="accommodation__item">
+        </a>
+      </article>
+      <article class="accommodation__item">
+        <a href="/" class="accommodation__link">
           <!-- h4 변경 -->
           <h4 class="sr-only">몰디브에 위치한 워터 방갈로</h4>
           <div class="accommodation__item__image">
@@ -137,15 +135,15 @@
           <h5 class="sr-only">숙소 정보</h5>
           <!-- 숙소 정보 변경 -->
           <ul class="accommodation__item__brief">
-            <li class="font-bold">MV, 몰디브</li>
+            <li class="font-bold"><abbr title="Maldiv">MV, </abbr>몰디브</li>
             <li>6,596km 거리</li>
             <li>9월 24일~29일</li>
             <li class="font-bold">₩781,552 /박</li>
-            <li class="review" aria-label="평점">NEW</li>
+            <li class="review" aria-label="새로운 숙소라 아직 평점이 없습니다">NEW</li>
           </ul>
           <button class="accommodation__item__favorite" aria-label="숙소 찜하기"></button>
-        </article>
-      </a>
+        </a>
+      </article>
     </section>
     <div class="accommodation__more">섬 카테고리 계속 검색하기<button type="button" class="accommodation__more__button">더
         보기</button></div>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>여행은 살아보는 거야 - 에어비앤비</title>
+</head>
+<body>
+  <!-- 조한 part -->
+  <header></header>
+
+  <!-- 윤하 part -->
+  <nav class="navigation">
+    <h2 class="sr-only">유형별 숙소 보기</h2>
+    <ul class="navigation__list">
+      <li class="navigation__item"><button type="button" class="navigation__item__button">섬</button></li>
+      <li class="navigation__item"><button type="button" class="navigation__item__button">국립공원</button></li>
+      <li class="navigation__item"><button type="button" class="navigation__item__button">통나무집</button></li>
+      <li class="navigation__item"><button type="button" class="navigation__item__button">기상천외한 숙소</button></li>
+      <li class="navigation__item"><button type="button" class="navigation__item__button">해변 근처</button></li>
+      <li class="navigation__item"><button type="button" class="navigation__item__button">초소형 주택</button></li>
+      <li class="navigation__item"><button type="button" class="navigation__item__button">디자인</button></li>
+      <li class="navigation__item"><button type="button" class="navigation__item__button">캠핑장</button></li>
+      <li class="navigation__item"><button type="button" class="navigation__item__button">A자형 주택</button></li>
+      <li class="navigation__item"><button type="button" class="navigation__item__button">호숫가</button></li>
+      <li class="navigation__item"><button type="button" class="navigation__item__button">북극</button></li>
+      <li class="navigation__item"><button type="button" class="navigation__item__button">멋진 수영장/button></li>
+        <li class="navigation__item"><button type="button" class="navigation__item__button">동굴</button></li>
+        <li class="navigation__item"><button type="button" class="navigation__item__button">서핑</button></li>
+        <li class="navigation__item"><button type="button" class="navigation__item__button">최고의 전망</button></li>
+        <li class="navigation__item"><button type="button" class="navigation__item__button">복토 주택</button></li>
+        <li class="navigation__item"><button type="button" class="navigation__item__button">열대지역</button></li>
+      </ul>
+    <button type="button" class="navigation__left arrow-button" aria-label="이전 숙소 유형 더보기"></button>
+    <button type="button" class="navigation__right arrow-button" aria-label="다음 숙소 유형 더보기"></button>
+    <button type="button" class="navigation__filter">필터</button>
+  </nav>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -151,6 +151,50 @@
         보기</button></div>
     <button type="button" class="accommodation__map">지도 표시하기</button>
   </main>
+  <footer class="footer">
+    <ul class="footer__main">
+      <li>
+        에어비앤비 지원
+        <ul class="footer__sub">
+          <li><a href="/">도움말 센터</a></li>
+          <li><a href="/">에어커버</a></li>
+          <li><a href="/">안전 정보</a></li>
+          <li><a href="/">장애인 지원</a></li>
+          <li><a href="/">예약 취소 옵션</a></li>
+          <li><a href="/">에어비앤비의 코로나19 대응 방안</a></li>
+          <li><a href="/">이웃 민원 신고</a></li>
+        </ul>
+      </li>
+      <li>
+        커뮤니티
+        <ul class="footer__sub">
+          <li><a href="/">Airbnb.org: 재난 구호 숙소</a></li>
+          <li><a href="/">아프간 난민 지원</a></li>
+          <li><a href="/">차별 철폐를 위한 노력</a></li>
+        </ul>
+      </li>
+      <li>
+        호스팅
+        <ul class="footer__sub">
+          <li><a href="/">호스팅 시작하기</a></li>
+          <li><a href="/">호스트를 위한 에어커버</a></li>
+          <li><a href="/">호스팅 자료 둘러보기</a></li>
+          <li><a href="/">커뮤니티 포럼 방문하기</a></li>
+          <li><a href="/">책임감 있는 호스팅</a></li>
+        </ul>
+      </li>
+      <li>
+        에어비앤비
+        <ul class="footer__sub">
+          <li><a href="/">뉴스룸</a></li>
+          <li><a href="/">새로운 기능에 대해 알아보기</a></li>
+          <li><a href="/">에어비앤비 공동창업자의 메시지</a></li>
+          <li><a href="/">채용정보</a></li>
+          <li><a href="/">투자자 정보</a></li>
+        </ul>
+      </li>
+    </ul>
+  </footer>
 </body>
 
 </html>


### PR DESCRIPTION
## PR을 간단하게 설명하여 주세요 😁
네비게이션 영역, 메인 영역, 푸터 지원 및 참고자료 영역 마크업을 완성했습니다. 


## 어떠한 점이 변화되었나요?
사진으로 첨부했는데 다음 영역들 마크업했습니다!

<네비게이션 영역>
![image](https://user-images.githubusercontent.com/87111950/182033170-04eb2e19-f5d3-4260-a43a-ff6f7ae00095.png)

<메인 영역>
![image](https://user-images.githubusercontent.com/87111950/182033194-6bce43b9-fa35-4865-b499-e3ff9bfaaa8c.png)
![image](https://user-images.githubusercontent.com/87111950/182033257-7dc4b5d5-2c91-42fd-96de-22b33983d1a9.png)

<푸터 지원 및 참고자료 영역>
![image](https://user-images.githubusercontent.com/87111950/182033221-3cce1aae-833b-47f8-87ea-f037a3046116.png)


## 변경사항 중 동료들이 알아야 할 부분을 설명해주세요!
<네비게이션 영역>
실제 에어비앤비 홈페이지에는 숙소 유형이 40개 정도 되는데 일단 17개로 줄여서 넣어놨습니다. 
각 숙소 유형 아이콘들은 sprite이미지로 위치만 변경하여 배경이미지로 삽입하면 좋을 것 같습니다.

<메인 영역>
숙소 정보는 지승님 조언을 받아 list로 작성했습니다.
숙소는 5개 복붙했고 추후에 각 숙소 이름과 정보는 수정할 예정입니다~


## 어떤 고민을 하였나요?
<메인 영역>
숙소 정보를 어떻게 semantic하게 마크업 할 수 있을지 고민을 해봤습니다. 
1)img-figcaption
figcaption은 이미지 자체에 대한 설명이기 때문에 숙소 정보(위치, 거리, 가격 등)를 나타내는 것과는 의도하는 바가 다르다. 
2)dt-dd
dt와 dd는 용어와 용어에 대한 정의를 나타낼 때 쓰는 태그이기 때문에 이 또한 의도와 맞지 않다.
3)table 
table은 2차원 정보(행과 열에 대한)를 나타내는 것인데 숙소 정보는 1차원적인 정보이다.
=> 결론적으로 리스트면 충분하다고 생각이 들어서 리스트로 작성했습니다. 


## Related Issue
<!--Close #이슈번호 로 사용해주세요! Squash and merge 사용해주세요!-- >

