### PR TITLE
메인 영역 스타일 완성 

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -18,9 +18,8 @@
       img {
         width: 100%;
         aspect-ratio: 1 / 1;
-        border-radius: 10px;
+        border-radius: rem(10px);
         background-color: $grayscale-gray1;
-        border: none;
       }
     }
 

--- a/main.scss
+++ b/main.scss
@@ -1,0 +1,62 @@
+@use "./styles" as *;
+
+// 임시 숨김 처리
+.accommodation__container button {
+  display: none;
+}
+
+.accommodation {
+  &__container {
+    display: grid;
+    padding: rem(34px);
+    grid-template-columns: repeat(auto-fit, minmax(rem(330px), auto));
+    gap: rem(34px);
+  }
+
+  &__item {
+    &__image {
+      img {
+        width: 100%;
+        aspect-ratio: 1 / 1;
+        border-radius: 10px;
+        background-color: $grayscale-gray1;
+        border: none;
+      }
+    }
+
+    &__brief {
+      @include text-15-regular;
+      position: relative;
+      margin-top: rem(15px);
+
+      .font-bold {
+        color: $grayscale-black;
+        abbr {
+          text-decoration: none !important;
+          cursor: help;
+        }
+      }
+
+      li:nth-child(n + 1):nth-child(-n + 3) {
+        margin-bottom: rem(4px);
+      }
+
+      li:nth-child(n + 2):nth-child(-n + 3) {
+        color: $grayscale-gray2;
+      }
+
+      li:nth-child(4) {
+        margin-top: rem(9px);
+      }
+
+      .review {
+        @include pos($t: 0, $r: 0);
+      }
+
+      .review::before {
+        content: "★";
+        display: inline;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## PR을 간단하게 설명하여 주세요 😁
메인 영역의 CSS를 마무리 했습니다!

<img width="1405" alt="image" src="https://user-images.githubusercontent.com/58802599/182364853-3e5aca54-928e-48f9-8a28-e9062051cccf.png">

## 어떠한 점이 변화되었나요?

메인 영역의 CSS가 추가되었습니다!

## 변경사항 중 동료들이 알아야 할 부분을 설명해주세요!

사진에서 보이듯, 이미지가 없는 경우 위와 같이 (이상한 테두리, 이미지 엑박) 나타납니다.
 
저는 `img`태그에 width, height과 background를 주는 방식으로 해결하려고 했는데, 
위와 같은 문제로 Skeleton UI를 검색해보니 별도로 다른 요소를 추가해(`div`, `::before` 등) Skeleton UI를 만들고 있더라구요! (Youtube, airbnb 참고)

그래서 어떤 방식으로 접근하면 좋을지 함께 고민해봤으면 좋겠습니다!

## 어떤 고민을 하였나요?

메인 영역을 flex로 배치할지, grid로 배치할지 여러 시도를 해보았습니다.
조금 더 호환성이 높은 flex로 배치를 하려고 시도했지만, 사이즈를 유동적으로 조정하면서 행과 열이 일정한 배치를 하기 어려워서
grid 방식을 선택했습니다. 이러한 그리드식(ㅎ) 배치에 활용할 수 있는 또 다른 방법을 찾으면 fallback 스타일로 추가하면 좋을 것 같아요!

## Related Issue
<!--Close #이슈번호 로 사용해주세요! Squash and merge 사용해주세요! -->
Close #17 
